### PR TITLE
Only update castbar spell if for the matched unit

### DIFF
--- a/Kui_Nameplates/Modules/Castbar.lua
+++ b/Kui_Nameplates/Modules/Castbar.lua
@@ -148,9 +148,13 @@ local function OnDefaultCastbarUpdate(self, elapsed)
 
 	f.castbar:Show()
 end
-local function OnDefaultCastbarEvent(self, event, ...)
+local function OnDefaultCastbarEvent(self, event, unit, spellName, spellRank)
 	if event == "UNIT_SPELLCAST_START" or event == "UNIT_SPELLCAST_CHANNEL_START" then
-		self.spellName = select(2, ...)
+		local frame = addon:GetUnitPlate(unit)
+		if not frame or not frame.castbar then
+			return
+		end
+		frame.castbar.spellName = spellName
 	end
 end
 ---------------------------------------------------------------------- create --


### PR DESCRIPTION
## Problem
There's a bug in the existing implementation where if `UNIT_SPELLCAST_START` or `UNIT_SPELLCAST_CHANNEL_START` events for any unit are received, it will update all castbars.

For example:
- have enemy nameplates on
- target a caster foe, initiate combat
- they start casting a spell, a bar will correctly appear for them
- you then start casting a spell

Result:
- your spell name will overwrite their castbar

## Fix Description
When an incoming event is received, attempt to fetch the corresponding unit plate. If it exists, update that one only.
