### PR TITLE
Current Percent health text option

### DIFF
--- a/Kui_Nameplates/Core/Config.lua
+++ b/Kui_Nameplates/Core/Config.lua
@@ -49,6 +49,7 @@ do
 		L["Maximum"] .. " |cff888888(156k)",
 		L["Percent"] .. " |cff888888(93)",
 		L["Deficit"] .. " |cff888888(-10.9k)",
+		L["CurrentPercent"] .. " |cff888888(145k(93))",
 		L["Blank"] .. " |cff888888(  )"
 	}
 

--- a/Kui_Nameplates/Core/Layout.lua
+++ b/Kui_Nameplates/Core/Layout.lua
@@ -45,6 +45,9 @@ local function SetFrameCentre(f)
 		f.x = floor((w / 2) - (addon.sizes.frame.width / 2))
 		f.y = floor((h / 2) - (addon.sizes.frame.height / 2))
 	end
+	
+	-- Add your upward offset here:
+    f.y = f.y + 20  -- move nameplates 20px higher
 end
 -- get default health bar colour, parse it into one of our custom colours
 -- and the reaction of the unit toward the player
@@ -170,6 +173,7 @@ do
 		function(f) return kui.num(f.health.max) end,
 		function(f) return floor(f.health.percent) end,
 		function(f) return "-" .. (kui.num(f.health.max - f.health.curr)) end,
+		function(f) return string.format("%s (%.0f%%)", kui.num(f.health.curr), f.health.percent) end, -- 6. Current HP (Percent)
 		function(f) return "" end
 	}
 

--- a/Kui_Nameplates/Locales/enUS.lua
+++ b/Kui_Nameplates/Locales/enUS.lua
@@ -99,6 +99,7 @@ L["Current"] = true
 L["Maximum"] = true
 L["Percent"] = true
 L["Deficit"] = true
+L["CurrentPercent"] = true
 L["Blank"] = true
 L["Never show health text"] = true
 L["Mouseover & target only"] = true


### PR DESCRIPTION
I added an option to display current health and percent at the same time like on ElvUI.

It's displayed like : 8k(95%)

![image](https://github.com/user-attachments/assets/270b2b22-c4cd-4052-927d-6aabe359b897)
